### PR TITLE
Implement Version-Aware Serialization

### DIFF
--- a/neopdf/src/metadata.rs
+++ b/neopdf/src/metadata.rs
@@ -32,7 +32,7 @@ pub enum InterpolatorType {
 /// Represents the information block of a PDF set, typically found in an `.info` file.
 /// This struct is deserialized from a YAML-like format.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct MetaData {
+pub struct MetaDataV1 {
     /// Description of the PDF set.
     #[serde(rename = "SetDesc")]
     pub set_desc: String,
@@ -126,6 +126,74 @@ pub struct MetaData {
     /// Number of active PDF flavors.
     #[serde(rename = "NumFlavors", default)]
     pub number_flavors: u32,
+}
+
+/// Version-aware MetaData wrapper that handles serialization compatibility.
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
+pub enum MetaData {
+    V1(MetaDataV1),
+}
+
+impl MetaData {
+    pub fn new_v1(data: MetaDataV1) -> Self {
+        Self::V1(data)
+    }
+
+    pub fn current(data: MetaDataV1) -> Self {
+        Self::V1(data)
+    }
+
+    pub fn to_latest(self) -> MetaDataV1 {
+        match self {
+            MetaData::V1(data) => data,
+        }
+    }
+
+    pub fn as_v1(&self) -> Option<&MetaDataV1> {
+        match self {
+            MetaData::V1(data) => Some(data),
+        }
+    }
+
+    pub fn as_v1_mut(&mut self) -> Option<&mut MetaDataV1> {
+        match self {
+            MetaData::V1(data) => Some(data),
+        }
+    }
+}
+
+impl std::ops::Deref for MetaData {
+    type Target = MetaDataV1;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            MetaData::V1(data) => data,
+        }
+    }
+}
+
+impl std::ops::DerefMut for MetaData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            MetaData::V1(data) => data,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MetaData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let v1 = MetaDataV1::deserialize(deserializer)?;
+        Ok(MetaData::V1(v1))
+        // if let Ok(v1) = MetaDataV1::deserialize(deserializer) {
+        //     return Ok(MetaData::V1(v1));
+        // }
+        // let v2 = MetaDataV2::deserialize(deserializer)?;
+        // Ok(MetaData::V2(v2))
+    }
 }
 
 impl fmt::Display for MetaData {

--- a/neopdf/src/metadata.rs
+++ b/neopdf/src/metadata.rs
@@ -2,8 +2,9 @@
 //!
 //! It includes the `MetaData` struct (deserialized from .info files), PDF set
 //! and interpolator type enums, and related utilities for handling PDF set information.
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
+use std::ops::{Deref, DerefMut};
 
 /// Represents the type of PDF set.
 #[repr(C)]
@@ -29,8 +30,10 @@ pub enum InterpolatorType {
     LogChebyshev,
 }
 
-/// Represents the information block of a PDF set, typically found in an `.info` file.
-/// This struct is deserialized from a YAML-like format.
+/// Represents the information block of a given set.
+///
+/// In order to support LHAPDF formats, the fields here are very much influenced by the
+/// LHAPSD `.info` file. This struct is generally deserialized from a YAML-like format.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MetaDataV1 {
     /// Description of the PDF set.
@@ -128,7 +131,7 @@ pub struct MetaDataV1 {
     pub number_flavors: u32,
 }
 
-/// Version-aware MetaData wrapper that handles serialization compatibility.
+/// Version-aware metadata wrapper that handles serialization compatibility.
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 pub enum MetaData {
@@ -136,34 +139,25 @@ pub enum MetaData {
 }
 
 impl MetaData {
+    /// Creates a new instance of V1 `MetaData`.
     pub fn new_v1(data: MetaDataV1) -> Self {
         Self::V1(data)
     }
 
-    pub fn current(data: MetaDataV1) -> Self {
+    /// Gets the current version as the latest available version.
+    pub fn current_v1(data: MetaDataV1) -> Self {
         Self::V1(data)
     }
 
-    pub fn to_latest(self) -> MetaDataV1 {
+    /// Gets the underlying data as the latest version.
+    pub fn as_latest(&self) -> MetaDataV1 {
         match self {
-            MetaData::V1(data) => data,
-        }
-    }
-
-    pub fn as_v1(&self) -> Option<&MetaDataV1> {
-        match self {
-            MetaData::V1(data) => Some(data),
-        }
-    }
-
-    pub fn as_v1_mut(&mut self) -> Option<&mut MetaDataV1> {
-        match self {
-            MetaData::V1(data) => Some(data),
+            MetaData::V1(data) => data.clone(),
         }
     }
 }
 
-impl std::ops::Deref for MetaData {
+impl Deref for MetaData {
     type Target = MetaDataV1;
 
     fn deref(&self) -> &Self::Target {
@@ -173,7 +167,7 @@ impl std::ops::Deref for MetaData {
     }
 }
 
-impl std::ops::DerefMut for MetaData {
+impl DerefMut for MetaData {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             MetaData::V1(data) => data,
@@ -184,15 +178,11 @@ impl std::ops::DerefMut for MetaData {
 impl<'de> Deserialize<'de> for MetaData {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         let v1 = MetaDataV1::deserialize(deserializer)?;
+
         Ok(MetaData::V1(v1))
-        // if let Ok(v1) = MetaDataV1::deserialize(deserializer) {
-        //     return Ok(MetaData::V1(v1));
-        // }
-        // let v2 = MetaDataV2::deserialize(deserializer)?;
-        // Ok(MetaData::V2(v2))
     }
 }
 

--- a/neopdf/src/writer.rs
+++ b/neopdf/src/writer.rs
@@ -25,13 +25,13 @@ use std::env;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
+use std::sync::Arc;
 
 use git_version::git_version;
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 
 use super::gridpdf::GridArray;
 use super::metadata::MetaData;
-use std::sync::Arc;
 
 const GIT_VERSION: &str = git_version!(
     args = ["--always", "--dirty", "--long", "--tags"],
@@ -76,10 +76,12 @@ impl GridArrayCollection {
         let buf_writer = BufWriter::new(file);
         let mut encoder = FrameEncoder::new(buf_writer);
 
-        let mut metadata_mut = metadata.clone();
+        let mut metadata_mut = metadata.as_v1().unwrap().clone();
         metadata_mut.git_version = GIT_VERSION.to_string();
         metadata_mut.code_version = CODE_VERSION.to_string();
-        let metadata_serialized = bincode::serialize(&metadata_mut)?;
+
+        let updated_metadata = MetaData::new_v1(metadata_mut);
+        let metadata_serialized = bincode::serialize(&updated_metadata)?;
         let metadata_size = metadata_serialized.len() as u64;
 
         let metadata_size_bytes = bincode::serialize(&metadata_size)?;
@@ -152,12 +154,14 @@ impl GridArrayCollection {
 
         let mut cursor = std::io::Cursor::new(decompressed);
 
-        // Read metadata
+        // Read versioned metadata
         let metadata_size: u64 = bincode::deserialize_from(&mut cursor)?;
         let mut metadata_bytes = vec![0u8; metadata_size as usize];
         cursor.read_exact(&mut metadata_bytes)?;
-        let metadata: MetaData = bincode::deserialize(&metadata_bytes)?;
-        let shared_metadata = Arc::new(metadata);
+
+        // Deserialize versioned metadata and convert to latest
+        let versioned_metadata: MetaData = bincode::deserialize(&metadata_bytes)?;
+        let shared_metadata = Arc::new(versioned_metadata);
         let count: u64 = bincode::deserialize_from(&mut cursor)?;
 
         // Read offset table size (but don't skip it!)
@@ -442,11 +446,11 @@ mod tests {
     use ndarray::Array1;
     use tempfile::NamedTempFile;
 
-    use crate::metadata::{InterpolatorType, SetType};
+    use crate::metadata::{InterpolatorType, MetaDataV1, SetType};
 
     #[test]
     fn test_collection_with_metadata() {
-        let metadata = MetaData {
+        let metadata_v1 = MetaDataV1 {
             set_desc: "Test PDF".into(),
             set_index: 1,
             num_members: 2,
@@ -479,6 +483,7 @@ mod tests {
             alphas_type: String::new(),
             number_flavors: 0,
         };
+        let metadata = MetaData::new_v1(metadata_v1);
 
         let test_grid = test_grid();
         let grids = vec![&test_grid, &test_grid];

--- a/neopdf/src/writer.rs
+++ b/neopdf/src/writer.rs
@@ -76,7 +76,7 @@ impl GridArrayCollection {
         let buf_writer = BufWriter::new(file);
         let mut encoder = FrameEncoder::new(buf_writer);
 
-        let mut metadata_mut = metadata.as_v1().unwrap().clone();
+        let mut metadata_mut = metadata.as_latest();
         metadata_mut.git_version = GIT_VERSION.to_string();
         metadata_mut.code_version = CODE_VERSION.to_string();
 

--- a/neopdf_capi/src/lib.rs
+++ b/neopdf_capi/src/lib.rs
@@ -5,7 +5,7 @@ use std::os::raw::{c_char, c_double, c_int};
 use std::slice;
 
 use neopdf::gridpdf::{ForcePositive, GridArray};
-use neopdf::metadata::{InterpolatorType, MetaData, SetType};
+use neopdf::metadata::{InterpolatorType, MetaData, MetaDataV1, SetType};
 use neopdf::parser::SubgridData;
 use neopdf::pdf::PDF;
 use neopdf::writer::GridArrayCollection;
@@ -815,7 +815,7 @@ fn process_metadata(meta: *const NeoPDFMetaData) -> Option<MetaData> {
     let flavor_scheme = unsafe { cstr_to_string(meta.phys_params.flavor_scheme) }?;
     let alphas_type = unsafe { cstr_to_string(meta.phys_params.alphas_type) }?;
 
-    let metadata = MetaData {
+    let metadata_v1 = MetaDataV1 {
         set_desc,
         set_index: meta.set_index,
         num_members: meta.num_members,
@@ -848,6 +848,7 @@ fn process_metadata(meta: *const NeoPDFMetaData) -> Option<MetaData> {
         alphas_type,
         number_flavors: meta.phys_params.number_flavors,
     };
+    let metadata = MetaData::new_v1(metadata_v1);
 
     Some(metadata)
 }

--- a/neopdf_pyapi/src/metadata.rs
+++ b/neopdf_pyapi/src/metadata.rs
@@ -1,5 +1,6 @@
-use neopdf::metadata::{InterpolatorType, MetaData, SetType};
 use pyo3::prelude::*;
+
+use neopdf::metadata::{InterpolatorType, MetaData, MetaDataV1, SetType};
 
 /// The type of the set.
 #[pyclass(eq, eq_int, name = "SetType")]
@@ -244,7 +245,7 @@ impl PyMetaData {
         let git_version = String::new();
         let code_version = String::new();
 
-        let meta = MetaData {
+        let meta_v1 = MetaDataV1 {
             set_desc,
             set_index,
             num_members,
@@ -278,7 +279,9 @@ impl PyMetaData {
             number_flavors: phys_params.number_flavors,
         };
 
-        Self { meta }
+        Self {
+            meta: MetaData::new_v1(meta_v1),
+        }
     }
 
     /// Convert to Python dictionary
@@ -338,73 +341,73 @@ impl PyMetaData {
 
     /// The description of the set.
     #[must_use]
-    pub const fn set_desc(&self) -> &String {
+    pub fn set_desc(&self) -> &String {
         &self.meta.set_desc
     }
 
     /// The index of the grid.
     #[must_use]
-    pub const fn set_index(&self) -> u32 {
+    pub fn set_index(&self) -> u32 {
         self.meta.set_index
     }
 
     /// The number of sets in the grid.
     #[must_use]
-    pub const fn number_sets(&self) -> u32 {
+    pub fn number_sets(&self) -> u32 {
         self.meta.num_members
     }
 
     /// The minimum value of `x` in the grid.
     #[must_use]
-    pub const fn x_min(&self) -> f64 {
+    pub fn x_min(&self) -> f64 {
         self.meta.x_min
     }
 
     /// The maximum value of `x` in the grid.
     #[must_use]
-    pub const fn x_max(&self) -> f64 {
+    pub fn x_max(&self) -> f64 {
         self.meta.x_max
     }
 
     /// The minimum value of `q` in the grid.
     #[must_use]
-    pub const fn q_min(&self) -> f64 {
+    pub fn q_min(&self) -> f64 {
         self.meta.q_min
     }
 
     /// The maximum value of `q` in the grid.
     #[must_use]
-    pub const fn q_max(&self) -> f64 {
+    pub fn q_max(&self) -> f64 {
         self.meta.q_max
     }
 
     /// The particle IDs of the grid.
     #[must_use]
-    pub const fn pids(&self) -> &Vec<i32> {
+    pub fn pids(&self) -> &Vec<i32> {
         &self.meta.flavors
     }
 
     /// The format of the grid.
     #[must_use]
-    pub const fn format(&self) -> &String {
+    pub fn format(&self) -> &String {
         &self.meta.format
     }
 
     /// The values of `q` for the running of the strong coupling constant.
     #[must_use]
-    pub const fn alphas_q(&self) -> &Vec<f64> {
+    pub fn alphas_q(&self) -> &Vec<f64> {
         &self.meta.alphas_q_values
     }
 
     /// The values of the running of the strong coupling constant.
     #[must_use]
-    pub const fn alphas_values(&self) -> &Vec<f64> {
+    pub fn alphas_values(&self) -> &Vec<f64> {
         &self.meta.alphas_vals
     }
 
     /// Whether the grid is polarised.
     #[must_use]
-    pub const fn is_polarised(&self) -> bool {
+    pub fn is_polarised(&self) -> bool {
         self.meta.polarised
     }
 
@@ -422,13 +425,13 @@ impl PyMetaData {
 
     /// The type of error.
     #[must_use]
-    pub const fn error_type(&self) -> &String {
+    pub fn error_type(&self) -> &String {
         &self.meta.error_type
     }
 
     /// The hadron PID.
     #[must_use]
-    pub const fn hadron_pid(&self) -> i32 {
+    pub fn hadron_pid(&self) -> i32 {
         self.meta.hadron_pid
     }
 }


### PR DESCRIPTION
The module `neopdf::writer` is very sensitive to changes of fields in the `MetaData` struct, and as a result could break backward compatibility in reading the Grid. The following implements the logic for `MetaData` versioning that would allow backward and forward compatibility.