### PR TITLE
Add CLI command to print the contents of the subgrids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -1207,9 +1213,11 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "clap 4.5.41",
+ "ndarray",
  "neopdf",
  "predicates",
  "tempfile",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1738,6 +1746,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
@@ -1745,7 +1766,7 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.60.2",
 ]
 
@@ -1982,7 +2003,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -1993,6 +2014,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2449,6 +2480,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2472,6 +2512,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2508,6 +2563,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2520,6 +2581,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2529,6 +2596,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2556,6 +2629,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2565,6 +2644,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2580,6 +2665,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2589,6 +2680,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2624,7 +2721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.0.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,31 +13,30 @@ version = "0.2.0-alpha1"
 
 [workspace.dependencies]
 # Core dependencies
-ndarray = { version = "0.16.1", features = ["serde"] }
-thiserror = "1.0.69"
-tempfile = "3.10.1"
-itertools = "0.13"
-
-# Core library dependencies
-ninterp = "0.7.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-rayon = "1.5"
-lz4_flex = "0.11"
 bincode = "1.3"
 flate2 = "1.1.2"
-indicatif = "0.17.8"
-reqwest = { version = "0.12.22", features = ["blocking", "gzip", "rustls-tls", "stream"], default-features = false }
-tar = "0.4.44"
-regex = "1.11.1"
 git-version = "0.3.9"
+indicatif = "0.17.8"
+itertools = "0.13"
+lz4_flex = "0.11"
+ndarray = { version = "0.16.1", features = ["serde"] }
+ninterp = "0.7.3"
+rayon = "1.5"
+regex = "1.11.1"
+reqwest = { version = "0.12.22", features = ["blocking", "gzip", "rustls-tls", "stream"], default-features = false }
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.9"
+tar = "0.4.44"
+tempfile = "3.10.1"
+thiserror = "1.0.69"
 
 # CLI dependencies
 clap = { version = "4.5", features = ["derive"] }
+terminal_size = "0.3.0"
 
 # Python bindings
-pyo3 = { version = "0.25", features = ["extension-module"] }
 numpy = "0.25"
+pyo3 = { version = "0.25", features = ["extension-module"] }
 
 # Build dependencies
 cbindgen = "0.26.0"
@@ -45,8 +44,8 @@ cbindgen = "0.26.0"
 # Dev dependencies for testing
 assert_cmd = "2.0.17"
 assert_fs = "1.1.3"
-predicates = "3.1.3"
 criterion = "0.6"
+predicates = "3.1.3"
 
 # Internal crates
 neopdf = { path = "./neopdf", version = "0.2.0-alpha1" }

--- a/neopdf_cli/Cargo.toml
+++ b/neopdf_cli/Cargo.toml
@@ -17,7 +17,9 @@ workspace = true
 
 [dependencies]
 clap.workspace = true
+ndarray.workspace = true
 neopdf.workspace = true
+terminal_size.workspace = true
 
 [[bin]]
 name = "neopdf"

--- a/neopdf_cli/src/read.rs
+++ b/neopdf_cli/src/read.rs
@@ -1,6 +1,8 @@
 //! CLI logic for reading PDF set information.
 
 use clap::{Args, Parser, Subcommand};
+use ndarray::{s, Axis};
+use terminal_size::{terminal_size, Width};
 
 /// Command-line interface for reading PDF set information.
 #[derive(Parser, Clone)]
@@ -20,8 +22,11 @@ pub enum ReadCommands {
     #[command(name = "num_subgrids")]
     NumSubgrids(PdfNameArgs),
     /// Print the subgrid info (nucleons, alphas, x, Q2) for a given subgrid index.
-    #[command(name = "subgrid_info")]
+    #[command(name = "subgrid-info")]
     SubgridInfo(SubgridInfoArgs),
+    /// Print the contents of a subgrid.
+    #[command(name = "subgrid")]
+    Subgrid(SubgridArgs),
     /// Print the git version of the code that generated the PDF.
     #[command(name = "git-version")]
     GitVersion(PdfNameArgs),
@@ -43,7 +48,7 @@ pub struct PdfNameArgs {
     pub pdf_name: String,
 }
 
-/// Arguments for the `subgrid_info` subcommand.
+/// Arguments for the `subgrid-info` subcommand.
 #[derive(Args, Clone)]
 pub struct SubgridInfoArgs {
     /// Name of the PDF set (LHAPDF or `NeoPDF` file)
@@ -57,7 +62,37 @@ pub struct SubgridInfoArgs {
     pub subgrid_index: usize,
 }
 
+/// Arguments for the `subgrid` subcommand.
+#[derive(Args, Clone)]
+pub struct SubgridArgs {
+    /// Name of the PDF set (LHAPDF or `NeoPDF` file)
+    #[arg(short, long)]
+    pub pdf_name: String,
+    /// Member index (0-based)
+    #[arg(short, long, default_value_t = 0)]
+    pub member: usize,
+    /// Subgrid index
+    #[arg(short, long)]
+    pub subgrid_index: usize,
+    /// PDG flavor ID
+    #[arg(short = 'i', long)]
+    pub pid: i32,
+    /// Nucleon index
+    #[arg(long, default_value_t = 0)]
+    pub nucleon_index: usize,
+    /// `Alpha_s` index
+    #[arg(long, default_value_t = 0)]
+    pub alphas_index: usize,
+    /// kT index
+    #[arg(long, default_value_t = 0)]
+    pub kt_index: usize,
+}
+
 /// Entry point for the read CLI.
+///
+/// # Panics
+///
+/// This function panics when a PID not present in the Grid is requested.
 #[allow(clippy::needless_pass_by_value)]
 pub fn main(cli: ReadCli) {
     match &cli.command {
@@ -77,6 +112,77 @@ pub fn main(cli: ReadCli) {
             println!("kT values: {:?}", subgrid.kts);
             println!("x values: {:?}", subgrid.xs);
             println!("Q2 values: {:?}", subgrid.q2s);
+        }
+        ReadCommands::Subgrid(args) => {
+            let pdf = neopdf::pdf::PDF::load(&args.pdf_name, args.member);
+            let subgrid = pdf.subgrid(args.subgrid_index);
+            let pids = pdf.pids();
+            let pid_to_find = if args.pid == 0 { 21 } else { args.pid };
+            let pid_idx = pids
+                .iter()
+                .position(|&p| p == pid_to_find)
+                .unwrap_or_else(|| panic!("PID {} not found in the grid.", args.pid));
+
+            if subgrid.nucleons.len() > 1 {
+                println!(
+                    "Displaying grid for Nucleon A = {}",
+                    subgrid.nucleons[args.nucleon_index]
+                );
+            }
+            if subgrid.alphas.len() > 1 {
+                println!(
+                    "Displaying grid for alpha_s = {}",
+                    subgrid.alphas[args.alphas_index]
+                );
+            }
+            if subgrid.kts.len() > 1 {
+                println!("Displaying grid for kT = {}", subgrid.kts[args.kt_index]);
+            }
+            println!();
+
+            let grid_slice = subgrid.grid.slice(s![
+                args.nucleon_index,
+                args.alphas_index,
+                pid_idx,
+                args.kt_index,
+                ..,
+                ..
+            ]);
+
+            let width = if let Some((Width(w), _)) = terminal_size() {
+                w as usize
+            } else {
+                80 // default terminal width
+            };
+
+            let col_width = 13;
+            let first_col_width = 13;
+            let num_cols = (width.saturating_sub(first_col_width)) / col_width;
+
+            if num_cols == 0 {
+                println!("Terminal too narrow to display the table.");
+                return;
+            }
+
+            let q2_chunks = subgrid.q2s.as_slice().unwrap().chunks(num_cols);
+            let grid_chunks = grid_slice.axis_chunks_iter(Axis(1), num_cols);
+
+            for (q2_chunk, grid_chunk) in q2_chunks.zip(grid_chunks) {
+                print!("{:>12}", "[x | Q2]");
+                for q2 in q2_chunk {
+                    print!("{q2:>12.5e}");
+                }
+                println!();
+
+                for (ix, x) in subgrid.xs.iter().enumerate() {
+                    print!("{x:>12.5e}");
+                    for iq2 in 0..q2_chunk.len() {
+                        print!("{:>12.5e}", grid_chunk[[ix, iq2]]);
+                    }
+                    println!();
+                }
+                println!();
+            }
         }
         ReadCommands::GitVersion(args) => {
             let pdf = neopdf::pdf::PDF::load(&args.pdf_name, 0);


### PR DESCRIPTION
Allows something like:
```sh
neopdf read subgrid --pdf-name check-tmds.neopdf.lz4 --member 0 --subgrid-index 0 --pid 2 --kt-index 3 
```
which prints the following:
```sh
    [x | Q2]   1.00001e0   1.01506e0   1.06146e0   1.14320e0   1.26745e0   1.44559e0   1.69470e0   2.03997e0   2.51836e0   3.18407e0   4.11675e0   5.43391e0   7.30927e0   1.00001e1   1.38873e1
  1.00000e-1 -6.70865e-1 -6.67763e-1 -6.58643e-1 -6.43812e-1 -6.22690e-1 -5.93769e-1 -5.58660e-1 -5.17687e-1 -4.71326e-1 -4.25254e-1 -3.78532e-1 -3.32081e-1 -2.87465e-1 -2.45652e-1 -2.07609e-1
  1.00374e-1 -6.73332e-1 -6.70181e-1 -6.60913e-1 -6.45846e-1 -6.24423e-1 -5.95161e-1 -5.59695e-1 -5.18382e-1 -4.71723e-1 -4.25394e-1 -3.78475e-1 -3.31890e-1 -2.87187e-1 -2.45324e-1 -2.07257e-1
  1.01502e-1 -6.80537e-1 -6.77233e-1 -6.67517e-1 -6.51737e-1 -6.29403e-1 -5.99120e-1 -5.62593e-1 -5.20270e-1 -4.72738e-1 -4.25655e-1 -3.78165e-1 -3.31199e-1 -2.86252e-1 -2.44252e-1 -2.06130e-1
....
    [x | Q2]   1.95341e1   2.77695e1   3.98062e1   5.74023e1   8.30750e1   1.20374e2   1.74211e2   2.51219e2   3.60111e2   5.11931e2   7.20089e2   1.00000e3   1.36814e3   1.84031e3   2.42912e3
  1.00000e-1 -1.72596e-1 -1.41442e-1 -1.14042e-1 -9.03001e-2 -6.98884e-2 -5.24739e-2 -3.79361e-2 -2.58860e-2 -1.60636e-2 -8.14743e-3 -1.86114e-3  3.07667e-3  6.84160e-3  9.76293e-3  1.19648e-2
  1.00374e-1 -1.72237e-1 -1.41089e-1 -1.13705e-1 -8.99850e-2 -6.95997e-2 -5.22137e-2 -3.77053e-2 -2.56835e-2 -1.58882e-2 -7.99681e-3 -1.73273e-3  3.18528e-3  6.93324e-3  9.83976e-3  1.20292e-2
  1.01502e-1 -1.71100e-1 -1.39980e-1 -1.12653e-1 -8.90079e-2 -6.87084e-2 -5.14131e-2 -3.69973e-2 -2.50638e-2 -1.53526e-2 -7.53764e-3 -1.34189e-3  3.51534e-3  7.21137e-3  1.00727e-2  1.22242e-2
  1.03402e-1 -1.69008e-1 -1.37970e-1 -1.10768e-1 -8.72736e-2 -6.71388e-2 -5.00125e-2 -3.57653e-2 -2.39905e-2 -1.44286e-2 -6.74842e-3 -6.72235e-4  4.07928e-3  7.68535e-3  1.04686e-2  1.25548e-2
...
```