### PR TITLE
Interface `TMDlib` to `NeoPDF`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "codespan-reporting"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +447,68 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "cxx"
+version = "1.0.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ba77f286ce5c44c7ba02de894b057bc0a605a210e3d81fa83b92d94586c0e1"
+dependencies = [
+ "cc",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c56fdf6fba27288d1fda3384062692e66dc40ca41bafd15f616dd4e8b0ac909"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap 2.10.0",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ade5eb6d6e6ef9c5631eff7e4f74e0e7109140e775f124d76904c0e5e6a202"
+dependencies = [
+ "clap 4.5.41",
+ "codespan-reporting",
+ "indexmap 2.10.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f99fe2f3f76a2ba40c5431f854efe3725c19a89f4d59966bca3ec561be940e"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6e5fa0545804d2d8d398a1e995203a1f2403a9f0651d50546462e61a28340e"
+dependencies = [
+ "indexmap 2.10.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "difflib"
@@ -536,6 +609,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1075,6 +1154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c349c75e1ab4a03bd6b33fe6cbd3c479c5dd443e44ad732664d72cb0e755475"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1320,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "neopdf_tmdlib"
+version = "0.2.0-alpha1"
+dependencies = [
+ "cc",
+ "cxx",
+ "cxx-build",
+ "pkg-config",
+]
+
+[[package]]
 name = "ninterp"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1447,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1825,6 +1929,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,7 @@ dependencies = [
  "clap 4.5.41",
  "ndarray",
  "neopdf",
+ "neopdf_tmdlib",
  "predicates",
  "tempfile",
  "terminal_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["neopdf", "neopdf_capi", "neopdf_cli", "neopdf_pyapi"]
+members = ["neopdf", "neopdf_capi", "neopdf_cli", "neopdf_pyapi", "neopdf_tmdlib"]
 resolver = "2"
 
 [workspace.package]

--- a/neopdf_cli/Cargo.toml
+++ b/neopdf_cli/Cargo.toml
@@ -20,6 +20,11 @@ clap.workspace = true
 ndarray.workspace = true
 neopdf.workspace = true
 terminal_size.workspace = true
+neopdf_tmdlib = { path = "../neopdf_tmdlib", optional = true }
+
+[features]
+default = []
+tmdlib = ["dep:neopdf_tmdlib"]
 
 [[bin]]
 name = "neopdf"

--- a/neopdf_cli/src/pdf.rs
+++ b/neopdf_cli/src/pdf.rs
@@ -23,6 +23,10 @@ pub enum PdfCommands {
     /// Evaluate `alphasQ2` for a given set, member, and Q2 value.
     #[command(name = "alphas_q2")]
     AlphasQ2(AlphasQ2Args),
+    /// Evaluate TMD PDF for a given set, member, and input values.
+    #[cfg(feature = "tmdlib")]
+    #[command(name = "xfx_q2_kt")]
+    XfxQ2Kt(XfxQ2KtArgs),
 }
 
 /// Arguments for the xfxQ2 subcommand.
@@ -56,8 +60,28 @@ pub struct AlphasQ2Args {
     pub q2: f64,
 }
 
+/// Arguments for the `xfxQ2_kt` subcommand.
+#[cfg(feature = "tmdlib")]
+#[derive(Args, Clone)]
+pub struct XfxQ2KtArgs {
+    /// Name of the TMD PDF set
+    #[arg(short, long)]
+    pub pdf_name: String,
+    /// Member index (0-based)
+    #[arg(short, long)]
+    pub member: usize,
+    /// PDG flavor ID
+    #[arg(short = 'i', long)]
+    pub pid: i32,
+    /// Input values (kt, x, q)
+    #[arg(required = true)]
+    pub inputs: Vec<f64>,
+}
+
 /// Entry point for the pdf CLI.
 #[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_wrap)]
 pub fn main(cli: PdfCli) {
     match &cli.command {
         PdfCommands::XfxQ2(args) => {
@@ -73,6 +97,30 @@ pub fn main(cli: PdfCli) {
             let pdf = neopdf::pdf::PDF::load(&args.pdf_name, args.member);
             let val = pdf.alphas_q2(args.q2);
             println!("{val}");
+        }
+        #[cfg(feature = "tmdlib")]
+        PdfCommands::XfxQ2Kt(args) => {
+            use neopdf_tmdlib::Tmd;
+            let mut tmd = Tmd::new();
+            tmd.init(&args.pdf_name, args.member as i32);
+
+            if args.inputs.len() < 3 {
+                eprintln!("Error: [kt, x, q] must be provided as input.");
+                process::exit(1);
+            }
+            let kt = args.inputs[0];
+            let x = args.inputs[1];
+            let q = args.inputs[2];
+
+            // The list of PIDs returned by TMDlib
+            let pids = [-6, -5, -4, -3, -2, -1, 21, 1, 2, 3, 4, 5, 6];
+            let pid_idx = pids.iter().position(|&p| p == args.pid).unwrap_or_else(|| {
+                eprintln!("Error: PID {} not supported by TMDlib interface.", args.pid);
+                process::exit(1);
+            });
+
+            let pdfs = tmd.xfxq2kt(x, kt, q);
+            println!("{}", pdfs[pid_idx]);
         }
     }
 }

--- a/neopdf_cli/tests/pdf.rs
+++ b/neopdf_cli/tests/pdf.rs
@@ -150,3 +150,26 @@ fn alphasq2_neopdf() {
         .success()
         .stdout("0.2485925816007479\n");
 }
+
+#[test]
+#[cfg(feature = "tmdlib")]
+fn xfxq2_kt_tmdlib() {
+    Command::cargo_bin("neopdf")
+        .unwrap()
+        .args([
+            "compute",
+            "xfx_q2_kt",
+            "--pdf-name",
+            "MAP22_grids_FF_Km_N3LL",
+            "--member",
+            "0",
+            "--pid",
+            "2",
+            "1.0",
+            "0.1",
+            "10.0",
+        ])
+        .assert()
+        .success()
+        .stdout("0.0655544\n");
+}

--- a/neopdf_tmdlib/Cargo.toml
+++ b/neopdf_tmdlib/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "neopdf_tmdlib"
+description = "NeoPDF's interface to TMDlib"
+authors = ["Tanjona R. Rabemananjara <tanjona.hepc@gmail.com>"]
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cc = "1.0"
+cxx-build = "1.0"
+pkg-config = "0.3"

--- a/neopdf_tmdlib/README.md
+++ b/neopdf_tmdlib/README.md
@@ -1,0 +1,3 @@
+# NeoPDF's interface to TMDlib
+
+This crate provides a Rust interface to the C++ TMDlib library.

--- a/neopdf_tmdlib/build.rs
+++ b/neopdf_tmdlib/build.rs
@@ -1,0 +1,63 @@
+#![allow(missing_docs)]
+
+use std::process::Command;
+
+fn main() {
+    let cxx_flags: Vec<String> = String::from_utf8(
+        Command::new("TMDlib-config")
+            .arg("--cppflags")
+            .output()
+            .expect("Could not find `TMDlib-config`, please install TMDlib and make sure `TMDlib-config` is in your PATH")
+            .stdout,
+    )
+    .unwrap()
+    .split_whitespace()
+    .map(ToOwned::to_owned)
+    .collect();
+
+    let include_dirs: Vec<_> = cxx_flags
+        .iter()
+        .filter_map(|token| token.strip_prefix("-I"))
+        .collect();
+
+    let libs = String::from_utf8(
+        Command::new("TMDlib-config")
+            .arg("--ldflags")
+            .output()
+            .expect("Could not find `TMDlib-config`, please install TMDlib and make sure `TMDlib-config` is in your PATH")
+            .stdout,
+    )
+    .unwrap();
+
+    for lib_path in libs
+        .split_whitespace()
+        .filter_map(|token| token.strip_prefix("-L"))
+    {
+        println!("cargo:rustc-link-search={lib_path}");
+    }
+
+    for lib in libs
+        .split_whitespace()
+        .filter_map(|token| token.strip_prefix("-l"))
+    {
+        println!("cargo:rustc-link-lib={lib}");
+    }
+
+    let mut build = cxx_build::bridge("src/lib.rs");
+    build.file("src/tmdlib.cpp").cpp(true);
+
+    for dir in &include_dirs {
+        build.include(*dir);
+    }
+
+    build.compile("tmd-bridge");
+
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=src/tmdlib.cpp");
+    println!("cargo:rerun-if-changed=src/tmdlib.hpp");
+
+    // Manually link to different libraries as TMDlib need them.
+    println!("cargo:rustc-link-lib=gsl");
+    println!("cargo:rustc-link-lib=gslcblas");
+    println!("cargo:rustc-link-lib=LHAPDF");
+}

--- a/neopdf_tmdlib/src/lib.rs
+++ b/neopdf_tmdlib/src/lib.rs
@@ -1,0 +1,86 @@
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::too_many_arguments)]
+#![allow(missing_docs)]
+
+use cxx::UniquePtr;
+
+#[cxx::bridge]
+pub mod ffi {
+    #[namespace = "TMDlib"]
+    unsafe extern "C++" {
+        include!("tmdlib/TMDlib.h");
+        type TMD;
+    }
+
+    unsafe extern "C++" {
+        include!("neopdf_tmdlib/src/tmdlib.hpp");
+
+        fn make_tmd() -> UniquePtr<TMD>;
+
+        fn tmd_init(tmd: Pin<&mut TMD>, setname: &str, member: i32);
+        fn tmd_init_set(tmd: Pin<&mut TMD>, setname: &str);
+        fn tmd_get_num_members(tmd: Pin<&mut TMD>) -> usize;
+        fn tmd_get_xmin(tmd: Pin<&mut TMD>) -> f64;
+        fn tmd_get_xmax(tmd: Pin<&mut TMD>) -> f64;
+        fn tmd_get_q2min(tmd: Pin<&mut TMD>) -> f64;
+        fn tmd_get_q2max(tmd: Pin<&mut TMD>) -> f64;
+        fn tmd_pdf(tmd: Pin<&mut TMD>, x: f64, kt: f64, q: f64) -> Vec<f64>;
+        fn tmd_set_verbosity(tmd: Pin<&mut TMD>, verbosity: i32);
+    }
+}
+
+pub struct Tmd {
+    ptr: UniquePtr<ffi::TMD>,
+}
+
+impl Tmd {
+    pub fn new() -> Self {
+        Self {
+            ptr: ffi::make_tmd(),
+        }
+    }
+
+    pub fn init(&mut self, setname: &str, member: i32) {
+        ffi::tmd_init(self.ptr.pin_mut(), setname, member);
+    }
+
+    pub fn init_set(&mut self, setname: &str) {
+        ffi::tmd_init_set(self.ptr.pin_mut(), setname);
+    }
+
+    pub fn num_members(&mut self) -> usize {
+        ffi::tmd_get_num_members(self.ptr.pin_mut())
+    }
+
+    pub fn x_min(&mut self) -> f64 {
+        ffi::tmd_get_xmin(self.ptr.pin_mut())
+    }
+
+    pub fn x_max(&mut self) -> f64 {
+        ffi::tmd_get_xmax(self.ptr.pin_mut())
+    }
+
+    pub fn q2_min(&mut self) -> f64 {
+        ffi::tmd_get_q2min(self.ptr.pin_mut())
+    }
+
+    pub fn q2_max(&mut self) -> f64 {
+        ffi::tmd_get_q2max(self.ptr.pin_mut())
+    }
+
+    pub fn xfxq2kt(&mut self, x: f64, kt: f64, q: f64) -> Vec<f64> {
+        ffi::tmd_pdf(self.ptr.pin_mut(), x, kt, q)
+    }
+
+    pub fn set_verbosity(&mut self, verbosity: i32) {
+        ffi::tmd_set_verbosity(self.ptr.pin_mut(), verbosity);
+    }
+}
+
+impl Default for Tmd {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/neopdf_tmdlib/src/tmdlib.cpp
+++ b/neopdf_tmdlib/src/tmdlib.cpp
@@ -1,0 +1,56 @@
+#include "neopdf_tmdlib/src/tmdlib.hpp"
+#include "tmdlib/TMDlib.h"
+#include <string>
+#include <vector>
+#include <iterator>
+#include <cmath>
+
+template <typename T>
+rust::Vec<T> std_vector_to_rust_vec(std::vector<T> vector)
+{
+    rust::Vec<T> result;
+    result.reserve(vector.size());
+    std::move(vector.begin(), vector.end(), std::back_inserter(result));
+    return result;
+}
+
+std::unique_ptr<TMDlib::TMD> make_tmd() {
+    return std::unique_ptr<TMDlib::TMD>(new TMDlib::TMD());
+}
+
+void tmd_init(TMDlib::TMD& tmd, rust::Str setname, int member) {
+    tmd.TMDinit(std::string(setname), member);
+}
+
+void tmd_init_set(TMDlib::TMD& tmd, rust::Str setname) {
+    tmd.TMDinit(std::string(setname));
+}
+
+size_t tmd_get_num_members(TMDlib::TMD& tmd) {
+    return tmd.TMDgetNumMembers();
+}
+
+double tmd_get_xmin(TMDlib::TMD& tmd) {
+    return tmd.TMDgetXmin();
+}
+
+double tmd_get_xmax(TMDlib::TMD& tmd) {
+    return tmd.TMDgetXmax();
+}
+
+double tmd_get_q2min(TMDlib::TMD& tmd) {
+    return tmd.TMDgetQ2min();
+}
+
+double tmd_get_q2max(TMDlib::TMD& tmd) {
+    return tmd.TMDgetQ2max();
+}
+
+rust::Vec<double> tmd_pdf(TMDlib::TMD& tmd, double x, double kt, double q) {
+    std::vector<double> pdfs = tmd.TMDpdf(x, 0.0, kt, q);
+    return std_vector_to_rust_vec(pdfs);
+}
+
+void tmd_set_verbosity(TMDlib::TMD& tmd, int verbosity) {
+    tmd.setVerbosity(verbosity);
+}

--- a/neopdf_tmdlib/src/tmdlib.hpp
+++ b/neopdf_tmdlib/src/tmdlib.hpp
@@ -1,0 +1,25 @@
+#ifndef TMDLIB_HPP
+#define TMDLIB_HPP
+
+#include "neopdf_tmdlib/src/lib.rs.h"
+#include "rust/cxx.h"
+
+#include <memory>
+
+namespace TMDlib {
+    class TMD;
+}
+
+std::unique_ptr<TMDlib::TMD> make_tmd();
+
+void tmd_init(TMDlib::TMD& tmd, rust::Str setname, int member);
+void tmd_init_set(TMDlib::TMD& tmd, rust::Str setname);
+size_t tmd_get_num_members(TMDlib::TMD& tmd);
+double tmd_get_xmin(TMDlib::TMD& tmd);
+double tmd_get_xmax(TMDlib::TMD& tmd);
+double tmd_get_q2min(TMDlib::TMD& tmd);
+double tmd_get_q2max(TMDlib::TMD& tmd);
+rust::Vec<double> tmd_pdf(TMDlib::TMD& tmd, double x, double kt, double q);
+void tmd_set_verbosity(TMDlib::TMD& tmd, int verbosity);
+
+#endif

--- a/neopdf_tmdlib/tests/xtmd.rs
+++ b/neopdf_tmdlib/tests/xtmd.rs
@@ -1,0 +1,23 @@
+#![allow(missing_docs)]
+
+use neopdf_tmdlib::Tmd;
+
+#[test]
+#[ignore]
+fn test_tmd_init_and_pdf() {
+    let mut tmd = Tmd::new();
+    let setname = "MAP22_grids_FF_Km_N3LL";
+
+    tmd.init(setname, 0);
+    let n_members = tmd.num_members();
+    assert!(n_members > 0, "TMD set should have members.");
+
+    let x = 1e-1;
+    let kt = 1.0;
+    let q = 10.0;
+    let pdfs = tmd.xfxq2kt(x, kt, q);
+    assert!(!pdfs.is_empty(), "PDF array should not be empty.");
+
+    let is_any_nonzero = pdfs.iter().any(|&val| val != 0.0);
+    assert!(is_any_nonzero, "All PDF values are zero!");
+}


### PR DESCRIPTION
This PR adds a `TMDlib` interface to `NeoPDF`. It allows using `TMDlib` to interpolate via the CLI:
```sh
neopdf compute xfx_q2_kt --pdf-name MAP22_grids_FF_Km_N3LL --member 0 --pid 2, 1.0 0.1 10.0
```
and convert a `TMDlib` set into a `NeoPDF` format.

**NOTE:** This requires `TMDlib` (and its dependencies) to be installed.